### PR TITLE
added controller and test code for location

### DIFF
--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationController.java
@@ -1,8 +1,40 @@
 package edu.ucsb.cs156.spring.backenddemo.controllers;
 
-import org.springframework.web.bind.annotation.RestController;
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name="Location info from https://nominatim.openstreetmap.org/search?q={location}&format=json")
+@Slf4j
 @RestController
+@RequestMapping("/api/locations")
 public class LocationController {
-    
+    ObjectMapper mapper = new ObjectMapper();
+
+    @Autowired
+    LocationQueryService LocationQueryService;
+
+    @Operation(summary="Get list of locations that match a given location name", description ="Uses API documented here: https://nominatim.org/release-docs/develop/api/Search/")
+    @GetMapping("/get")
+    public ResponseEntity<String> getLocations(
+        @Parameter(name="location", example="name to search, e.g. 'Isla Vista' or 'Eiffel Tower'") @RequestParam String location
+    ) throws JsonProcessingException {
+        log.info("getLocations: location={}", location);
+        String result = LocationQueryService.getJSON(location);
+        return ResponseEntity.ok().body(result);
+    }
 }

--- a/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
+++ b/src/main/java/edu/ucsb/cs156/spring/backenddemo/services/LocationQueryService.java
@@ -24,8 +24,8 @@ public class LocationQueryService {
     public LocationQueryService(RestTemplateBuilder restTemplateBuilder) {
         restTemplate = restTemplateBuilder.build();
     }
-
-    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search/{location}?format=json";
+    
+    public static final String ENDPOINT = "https://nominatim.openstreetmap.org/search?q={location}&format=json";
 
     public String getJSON(String location) throws HttpClientErrorException {
         log.info("location={}", location);

--- a/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/spring/backenddemo/controllers/LocationControllerTests.java
@@ -1,0 +1,51 @@
+package edu.ucsb.cs156.spring.backenddemo.controllers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import edu.ucsb.cs156.spring.backenddemo.services.LocationQueryService;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+@WebMvcTest(value = LocationController.class)
+public class LocationControllerTests {
+    private ObjectMapper mapper = new ObjectMapper();
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  LocationQueryService mockLocationQueryService;
+
+
+  @Test
+  public void test_getCountryCodes() throws Exception {
+  
+    String fakeJsonResult="{ \"fake\" : \"result\" }";
+    String location = "Tokyo";
+    when(mockLocationQueryService.getJSON(eq(location))).thenReturn(fakeJsonResult);
+
+    String url = String.format("/api/locations/get?location=%s", location);
+
+    MvcResult response = mockMvc
+        .perform( get(url).contentType("application/json"))
+        .andExpect(status().isOk()).andReturn();
+
+    String responseString = response.getResponse().getContentAsString();
+
+    assertEquals(fakeJsonResult, responseString);
+  }
+}


### PR DESCRIPTION
In this PR, we add an endpoint `/api/location/get` that can be used to get information
about the location.

Closes #9


